### PR TITLE
add scaleX and scaleY

### DIFF
--- a/src/Collage.elm
+++ b/src/Collage.elm
@@ -359,11 +359,36 @@ Scaling by 2 doubles both dimensions and quadruples the area.
 -}
 scale : Float -> Collage msg -> Collage msg
 scale s collage =
+    scaleXY ( s, s ) collage
+
+
+{-| Scale a collage horizontally (in its local space) by a given factor.
+
+Scaling by 2 doubles the width.
+
+-}
+scaleX : Float -> Collage msg -> Collage msg
+scaleX s collage =
+    scaleXY ( s, 1 ) collage
+
+
+{-| Scale a collage vertically (in its local space) by a given factor.
+
+Scaling by 2 doubles the height.
+
+-}
+scaleY : Float -> Collage msg -> Collage msg
+scaleY s collage =
+    scaleXY ( 1, s ) collage
+
+
+scaleXY : ( Float, Float ) -> Collage msg -> Collage msg
+scaleXY ( sx, sy ) collage =
     let
-        ( sx, sy ) = 
+        ( sx0, sy0 ) =
             collage.scale
     in
-    { collage | scale = ( sx * s, sy * s ) }
+    { collage | scale = ( sx0 * sx, sy0 * sy ) }
 
 
 {-| Rotate a collage by a given angle.

--- a/src/Collage.elm
+++ b/src/Collage.elm
@@ -40,6 +40,8 @@ module Collage
         , roundedRectangle
         , roundedSquare
         , scale
+        , scaleX
+        , scaleY
         , segment
         , semithick
         , shift
@@ -162,7 +164,7 @@ Ok, you get the grip!
 
 ## Transforming collages
 
-@docs shift, scale, rotate, opacity
+@docs shift, scale, scaleX, scaleY, rotate, opacity
 
 
 ## Grouping collages

--- a/src/Collage.elm
+++ b/src/Collage.elm
@@ -366,7 +366,7 @@ scale s collage =
 
 {-| Scale a collage horizontally (in its local space) by a given factor.
 
-Scaling by 2 doubles the width.
+Scaling by 2 doubles the width and doubles the area.
 
 -}
 scaleX : Float -> Collage msg -> Collage msg
@@ -376,7 +376,7 @@ scaleX s collage =
 
 {-| Scale a collage vertically (in its local space) by a given factor.
 
-Scaling by 2 doubles the height.
+Scaling by 2 doubles the height and doubles the area.
 
 -}
 scaleY : Float -> Collage msg -> Collage msg

--- a/src/Collage.elm
+++ b/src/Collage.elm
@@ -359,7 +359,11 @@ Scaling by 2 doubles both dimensions and quadruples the area.
 -}
 scale : Float -> Collage msg -> Collage msg
 scale s collage =
-    { collage | scale = collage.scale * s }
+    let
+        ( sx, sy ) = 
+            collage.scale
+    in
+    { collage | scale = ( sx * s, sy * s ) }
 
 
 {-| Rotate a collage by a given angle.

--- a/src/Collage/Core.elm
+++ b/src/Collage/Core.elm
@@ -32,7 +32,7 @@ type alias Point =
 type alias Collage fill line text msg =
     { origin : Point
     , theta : Float
-    , scale : Float
+    , scale : ( Float, Float )
     , alpha : Float
     , handlers : List ( String, Json.Decoder msg )
     , basic : BasicCollage fill line text msg
@@ -53,7 +53,7 @@ collage : BasicCollage fill line text msg -> Collage fill line text msg
 collage basic =
     { origin = ( 0, 0 )
     , theta = 0
-    , scale = 1
+    , scale = ( 1, 1 )
     , alpha = 1
     , handlers = []
     , basic = basic

--- a/src/Collage/Layout.elm
+++ b/src/Collage/Layout.elm
@@ -268,17 +268,17 @@ distances collage =
         ( tx, ty ) =
             collage.origin
 
-        s =
+        ( sx, sy ) =
             collage.scale
     in
     { up =
-        s * max 0 (dist.up + ty)
+        sy * max 0 (dist.up + ty)
     , down =
-        s * max 0 (dist.down - ty)
+        sy * max 0 (dist.down - ty)
     , right =
-        s * max 0 (dist.right + tx)
+        sx * max 0 (dist.right + tx)
     , left =
-        s * max 0 (dist.left - tx)
+        sx * max 0 (dist.left - tx)
     }
 
 

--- a/src/Collage/Render.elm
+++ b/src/Collage/Render.elm
@@ -331,11 +331,14 @@ evalTransform collage =
         theta =
             toString <| -collage.theta / 2 / pi * 360
 
-        scale =
-            toString <| collage.scale
+        sx =
+            toString <| Tuple.first collage.scale
+
+        sy =
+            toString <| Tuple.second collage.scale
     in
     String.concat
-        [ "translate(", x, ",", y, ") rotate(", theta, ") scale(", scale, ")" ]
+        [ "translate(", x, ",", y, ") rotate(", theta, ") scale(", sx, ",", sy, ")" ]
 
 
 decodeFill : Core.FillStyle -> String


### PR DESCRIPTION
I saw the TODO where you wanted to give them cooler names, but I think these names are less confusing and more in line with [Elm GraphicSVG](http://package.elm-lang.org/packages/MacCASOutreach/graphicsvg/latest/GraphicSVG#scaleX) and [Elm Graphics](http://package.elm-lang.org/packages/evancz/elm-graphics/latest/Transform#scaleX).

I implemented this with a tuple `scale : (Float, Float)`, but it could have been done with a record. I'm not sure which is better.