### PR TITLE
Add PointerEvents to support touch events on mobile

### DIFF
--- a/src/Collage/Events.elm
+++ b/src/Collage/Events.elm
@@ -45,8 +45,12 @@ where `drawing : { r | collage : Collage, id : Id }`
 
 # Mouse events
 
-@docs onClick, onDoubleClick, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, onMouseOver, onMouseOut
+@docs onClick, onDoubleClick, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, onMouseOver, onMouseOut, onMouseMove
 
+
+# Pointer events
+
+@docs onPointerDown, onPointerEnter, onPointerLeave, onPointerMove, onPointerOut, onPointerOver, onPointerUp
 
 # Focus events
 

--- a/src/Collage/Events.elm
+++ b/src/Collage/Events.elm
@@ -12,6 +12,13 @@ module Collage.Events
         , onMouseOver
         , onMouseUp
         , onMouseMove
+        , onPointerDown
+        , onPointerEnter
+        , onPointerLeave
+        , onPointerOut
+        , onPointerOver
+        , onPointerUp
+        , onPointerMove
         )
 
 {-| Use this module to make your graphics interactive.
@@ -156,3 +163,38 @@ onFocusIn =
 onFocusOut : msg -> Collage msg -> Collage msg
 onFocusOut =
     simpleOn "focusout"
+
+{-| -}
+onPointerMove : (Point -> msg) -> Collage msg -> Collage msg
+onPointerMove =
+    mouseOn "pointermove"
+
+{-| -}
+onPointerDown : (Point -> msg) -> Collage msg -> Collage msg
+onPointerDown =
+    mouseOn "pointerdown"
+
+{-| -}
+onPointerUp : (Point -> msg) -> Collage msg -> Collage msg
+onPointerUp =
+    mouseOn "pointerup"
+
+{-| -}
+onPointerEnter : (Point -> msg) -> Collage msg -> Collage msg
+onPointerEnter =
+    mouseOn "pointerenter"
+
+{-| -}
+onPointerLeave : (Point -> msg) -> Collage msg -> Collage msg
+onPointerLeave =
+    mouseOn "pointerleave"
+
+{-| -}
+onPointerOut : (Point -> msg) -> Collage msg -> Collage msg
+onPointerOut =
+    mouseOn "pointerout"
+
+{-| -}
+onPointerOver : (Point -> msg) -> Collage msg -> Collage msg
+onPointerOver =
+    mouseOn "pointerover"


### PR DESCRIPTION
As I was experimenting further, I wanted to support touch events as well. I found out that it's relatively easy just by adding [`PointerEvent`](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent) , which are quite similar to `MouseEvent`.

I've tested the new events in my project, and they should work fine.