### PR TITLE
update LineStyle field names in doc

### DIFF
--- a/src/Collage.elm
+++ b/src/Collage.elm
@@ -825,12 +825,12 @@ You can also update existing line styles with record updates.
 
 To define a red, dashed line style with a thickness of 5px:
 
-    { color = rgb255 255 20 20
+    { fill = rgb255 255 20 20
     , thickness = 5
     , cap = Flat
     , join = Sharp
-    , dashing = [ 8, 4 ]
-    , dashOffset = 0
+    , dashPattern = [ 8, 4 ]
+    , dashPhase = 0
     }
 
 -}


### PR DESCRIPTION
The `LineStyle` documentation was still referring to the old record field names.
The names are now updated:
```
color --now fill
dashing --now dashPattern
dashOffset --now dashPhase
```