### PR TITLE
Allow extra attributes to be attached to an HTML element

### DIFF
--- a/src/Collage.elm
+++ b/src/Collage.elm
@@ -774,9 +774,9 @@ image dims =
 The resulting collage is subject to all of the regular transformations.
 
 -}
-html : ( Float, Float ) -> Html msg -> Collage msg
-html dims =
-  Core.collage << Core.Html dims
+html : ( Float, Float ) -> List (Html.Attribute msg) -> Html msg -> Collage msg
+html dims attrs =
+  Core.collage << Core.Html dims attrs
 
 
 

--- a/src/Collage/Core.elm
+++ b/src/Collage/Core.elm
@@ -40,7 +40,7 @@ type BasicCollage fill line text msg
   | Path line Path
   | Text ( Float, Float ) (Text text)
   | Image ( Float, Float ) String
-  | Html ( Float, Float ) (Html msg)
+  | Html ( Float, Float ) (List (Html.Attribute msg)) (Html msg)
     --FIXME: Implement grouping as fold over stacking?
   | Group (List (Collage fill line text msg))
   | Subcollage (Collage fill line text msg) (Collage fill line text msg)

--- a/src/Collage/Layout.elm
+++ b/src/Collage/Layout.elm
@@ -274,7 +274,7 @@ handleBasic basic =
       handleBox 0 dims
     Core.Image dims _ ->
       handleBox 0 dims
-    Core.Html dims _ ->
+    Core.Html dims _ _ ->
       handleBox 0 dims
     -- Groups --
     Core.Group cols ->

--- a/src/Collage/Render.elm
+++ b/src/Collage/Render.elm
@@ -151,12 +151,13 @@ render collage =
           ++ events collage.handlers
         )
         []
-    Core.Html ( w, h ) html ->
+    Core.Html ( w, h ) extraAttrs html ->
       Svg.foreignObject
         ([ Svg.id name ]
           ++ box w h
           ++ attrs collage
           ++ events collage.handlers
+          ++ extraAttrs
         )
         [ html ]
     Core.Group collages ->


### PR DESCRIPTION
I appreciate you no longer wish to maintain this library. But if there's one final change worth making, it's this, as it makes the library's major escape hatch more flexible, so a lot of limitations can be overcome, albeit in a relatively ugly low-level way.

If you're curious about a use case where this is necessary, see [here](https://github.com/georgefst/monpad/commit/554351f75de9ee8db90805c889d0e54d03fb097e).